### PR TITLE
Added reflection ordering

### DIFF
--- a/ECSSerializer/Serializers/Attributes.meta
+++ b/ECSSerializer/Serializers/Attributes.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7342f6c6182e4b8886f94e193131942a
+timeCreated: 1607519803

--- a/ECSSerializer/Serializers/Attributes/OrderAttribute.cs
+++ b/ECSSerializer/Serializers/Attributes/OrderAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace ME.ECS.Serializer.Attributes
+{
+	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
+	public sealed class OrderAttribute : Attribute
+	{
+		private readonly int order_;
+		public OrderAttribute([CallerLineNumber] int order = 0)
+		{
+			order_ = order;
+		}
+
+		public int Order { get { return order_; } }
+	}
+}

--- a/ECSSerializer/Serializers/Attributes/OrderAttribute.cs.meta
+++ b/ECSSerializer/Serializers/Attributes/OrderAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 86fedd12e86743249557023b3ddcbc27
+timeCreated: 1607519677

--- a/ECSSerializer/Serializers/ReflectionHelper.cs
+++ b/ECSSerializer/Serializers/ReflectionHelper.cs
@@ -1,6 +1,8 @@
-namespace ME.ECS.Serializer {
+using System;
+using System.Linq;
+using ME.ECS.Serializer.Attributes;
 
-    using Enumerable = System.Linq.Enumerable;
+namespace ME.ECS.Serializer {
 
     public static class ReflectionHelper {
         
@@ -24,7 +26,12 @@ namespace ME.ECS.Serializer {
                                                  )
                 );
 
-                fieldInfos = Enumerable.ToArray(Enumerable.OrderBy(fieldInfosArr, x => x.Name));
+                fieldInfos = fieldInfosArr
+	                .OrderByDescending(x => Attribute.IsDefined(x, typeof(OrderAttribute)))
+	                .ThenBy(x => ((OrderAttribute)x.GetCustomAttributes(typeof(OrderAttribute), false)
+		                .SingleOrDefault())?.Order)
+	                .ToArray();
+
                 ReflectionHelper.fieldInfoCache.Add(type, fieldInfos);
 
             }


### PR DESCRIPTION
Use the [Order] attribute for properties and fields to order them. If there is no attribute, then the property/field is placed at the end.